### PR TITLE
Update workflow to use 'main' as default branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,11 @@
 name: Build
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths-ignore:
     - 'docs/**'
   pull_request:
-    branches: [master]
+    branches: [main]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -23,7 +23,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Commit files
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           date > docs/updated.txt
           git config user.name github-actions


### PR DESCRIPTION
# Rename Default Branch to 'main'

This PR updates repository configurations to use 'main' as the default branch name instead of 'master'.

## Changes

- Update GitHub Actions workflow to reference 'main' branch
- Update branch references in workflow conditions

## Implementation Steps

After merging this PR, we need to:

1. Go to repository settings
2. Navigate to "Branches" section
3. Rename the default branch from 'master' to 'main'
4. Update local repositories using:
   ```bash
   git branch -m master main
   git fetch origin
   git branch -u origin/main main
```