### PR TITLE
feat: add knee rehabilitation and leg strength routines

### DIFF
--- a/src/js/routines/knee_rehab.js
+++ b/src/js/routines/knee_rehab.js
@@ -1,0 +1,71 @@
+export default
+{
+    "name": "Knee Rehabilitation",
+    "sub_routines": [
+        {
+            "name": "Hip & Hamstring Focus",
+            "intervals": [
+                {
+                    "name": "Gentle Leg Swings",
+                    "duration": 30
+                },
+                {
+                    "name": "Rest",
+                    "duration": 15
+                },
+                {
+                    "name": "Bridge Hold",
+                    "duration": 30
+                },
+                {
+                    "name": "Rest",
+                    "duration": 15
+                },
+                {
+                    "name": "Clamshells Left",
+                    "duration": 30
+                },
+                {
+                    "name": "Rest",
+                    "duration": 15
+                },
+                {
+                    "name": "Clamshells Right",
+                    "duration": 30
+                },
+                {
+                    "name": "Rest",
+                    "duration": 15
+                },
+                {
+                    "name": "Standing Hip Abduction Left",
+                    "duration": 30
+                },
+                {
+                    "name": "Rest",
+                    "duration": 15
+                },
+                {
+                    "name": "Standing Hip Abduction Right",
+                    "duration": 30
+                },
+                {
+                    "name": "Rest",
+                    "duration": 15
+                },
+                {
+                    "name": "Hamstring Slides",
+                    "duration": 30
+                },
+                {
+                    "name": "Rest",
+                    "duration": 15
+                }
+            ],
+            "sets": 3,
+            "duration_between_sets": 60,
+            "start_delay": 10,
+            "end_delay": 0
+        }
+    ]
+};

--- a/src/js/routines/leg_strength.js
+++ b/src/js/routines/leg_strength.js
@@ -1,0 +1,99 @@
+export default
+{
+    "name": "Leg Strength Builder",
+    "sub_routines": [
+        {
+            "name": "Warm Up",
+            "intervals": [
+                {
+                    "name": "Ankle Circles",
+                    "duration": 20
+                },
+                {
+                    "name": "Rest",
+                    "duration": 10
+                },
+                {
+                    "name": "Knee Circles",
+                    "duration": 20
+                },
+                {
+                    "name": "Rest",
+                    "duration": 10
+                },
+                {
+                    "name": "Hip Circles",
+                    "duration": 20
+                },
+                {
+                    "name": "Rest",
+                    "duration": 20
+                }
+            ],
+            "sets": 1,
+            "start_delay": 5,
+            "end_delay": 0
+        },
+        {
+            "name": "Main Workout",
+            "intervals": [
+                {
+                    "name": "Bodyweight Squats",
+                    "duration": 40
+                },
+                {
+                    "name": "Rest",
+                    "duration": 20
+                },
+                {
+                    "name": "Split Squat Left",
+                    "duration": 30
+                },
+                {
+                    "name": "Rest",
+                    "duration": 15
+                },
+                {
+                    "name": "Split Squat Right",
+                    "duration": 30
+                },
+                {
+                    "name": "Rest",
+                    "duration": 20
+                },
+                {
+                    "name": "Double Calf Raises",
+                    "duration": 30
+                },
+                {
+                    "name": "Rest",
+                    "duration": 15
+                },
+                {
+                    "name": "Single Calf Raise Left",
+                    "duration": 20
+                },
+                {
+                    "name": "Rest",
+                    "duration": 10
+                },
+                {
+                    "name": "Single Calf Raise Right",
+                    "duration": 20
+                },
+                {
+                    "name": "Rest",
+                    "duration": 15
+                },
+                {
+                    "name": "Good Mornings",
+                    "duration": 30
+                }
+            ],
+            "sets": 2,
+            "duration_between_sets": 45,
+            "start_delay": 10,
+            "end_delay": 0
+        }
+    ]
+};

--- a/src/js/routines/routines.js
+++ b/src/js/routines/routines.js
@@ -11,6 +11,8 @@ import w3s1 from './week_3_session_1.js';
 import w3s2 from './week_3_session_2.js';
 import w3s3 from './week_3_session_3.js';
 import t from './test.js';
+import kr from './knee_rehab.js';
+import ls from './leg_strength.js';
 
 export default[
     s1,
@@ -25,5 +27,7 @@ export default[
     w3s1,
     w3s2,
     w3s3,
-    t
+    t,
+    kr,
+    ls
   ];


### PR DESCRIPTION
# Add Knee Rehabilitation and Leg Strength Routines

This PR adds two new fitness routines focused on lower body strength and rehabilitation:

1. **Knee Rehabilitation Routine**
   - Focus on hip and hamstring exercises
   - 3 sets with adequate rest periods
   - Includes: leg swings, bridges, clamshells, hip abductions, and hamstring slides
   - Total duration: ~15 minutes

2. **Leg Strength Builder**
   - Progressive warm-up sequence
   - Focus on hamstring and calf strength
   - 2 sets of main workout
   - Includes: squats, split squats, calf raises, and good mornings
   - Total duration: ~15 minutes

Both routines are designed with proper progression and adequate rest periods to maintain good form and prevent fatigue-related injuries.