### PR TITLE
Tidy UI: title navigation, hide group names, enlarge timer UI, show 4 upcoming items

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,7 +9,7 @@
   </head>
   <body>
     <div id="app">
-      <h1>Fitness Routine Timer</h1>
+  <h1 id="appTitle">Fitness Routine Timer</h1>
       <div id="routine_list"></div>
       <div id="routine_detail"></div>
       <div id="routine_timer"></div>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -291,6 +291,41 @@ const onLoaded = () => {
 }
 document.addEventListener("DOMContentLoaded", onLoaded);
 
+// Make the app title clickable to always return to the routines list
+const appTitle = document.getElementById('appTitle');
+if (appTitle) {
+  appTitle.style.cursor = 'pointer';
+  appTitle.addEventListener('click', (ev) => {
+    try {
+      if (myNS.routine_timer) {
+        // Mirror the behavior of the #end button: pause, confirm, then cleanup or unpause
+        myNS.routine_timer.pause();
+        if (confirm("Are you sure you want to end?")) {
+          u("#routine_timer .container").remove();
+          myNS.routine_timer = null;
+          if (wakeLock) {
+            try { wakeLock.release(); } catch (e) { /* ignore */ }
+            wakeLock = null;
+          }
+          u("#routine_detail .container").remove();
+          displayRoutineList();
+          return;
+        } else {
+          myNS.routine_timer.unpause();
+          return;
+        }
+      }
+    } catch (e) {
+      console.error('Error handling title click while timer running', e);
+    }
+
+    // No routine running: clear detail and timer views and show list
+    u("#routine_detail .container").remove();
+    u("#routine_timer .container").remove();
+    displayRoutineList();
+  });
+}
+
 if ("serviceWorker" in navigator) {
   window.addEventListener("load", function () {
     navigator.serviceWorker

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -225,7 +225,9 @@ const setupModal = (routine) => {
 };
 
 const displayRoutine = (routine) => {
+  // Remove the list containers and their group headers so the list UI fully clears
   u("#routine_list .container").remove();
+  u("#routine_list .group-header").remove();
   document.getElementById("routine_detail").innerHTML = showRoutineDetail(routine);
   setupModal(routine);
   u("#routine_detail #close").on("click", (ev) => {

--- a/src/js/view_models.js
+++ b/src/js/view_models.js
@@ -39,7 +39,7 @@ export class RoutineTimerVM {
     get coming_up() {
         var i;
         var coming_up = [];
-        for( i = this.current_index + 1; i <= Math.min(this.current_index + 3, this.countdown_timers.length -1); i++){
+    for( i = this.current_index + 1; i <= Math.min(this.current_index + 4, this.countdown_timers.length -1); i++){
             coming_up.push(this.countdown_timers[i]);
         }
         return coming_up;

--- a/src/style.less
+++ b/src/style.less
@@ -24,8 +24,8 @@
 }
 
 // Improve touch targets
-button, 
-a.btn, 
+button,
+a.btn,
 summary {
   touch-action: manipulation;
   user-select: none;
@@ -47,7 +47,7 @@ body {
 .detail-container {
   text-align: left;
   margin: 1rem 0;
-  
+
   summary {
     font-size: 1.25rem;
     font-weight: 500;
@@ -56,12 +56,12 @@ body {
     background: var(--card-bg);
     border-radius: 0.5rem;
     box-shadow: var(--shadow-sm);
-    
+
     &:hover {
       background: #F3F4F6;
     }
   }
-  
+
   .exercise-row {
     display: flex;
     align-items: center;
@@ -180,16 +180,22 @@ body {
 }
 
 @keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes slideIn {
-  from { 
+  from {
     opacity: 0;
     transform: translateY(20px);
   }
-  to { 
+
+  to {
     opacity: 1;
     transform: translateY(0);
   }
@@ -207,7 +213,7 @@ h1 {
   text-align: left;
   padding: 1rem 0.5rem 0.5rem;
   margin-top: 1rem;
-  
+
   h2 {
     color: var(--primary);
     font-size: 1.5rem;
@@ -243,7 +249,7 @@ h1 {
   overflow: hidden;
   padding: 1.5rem;
   width: 100%;
-  
+
   &:hover {
     box-shadow: var(--shadow-lg);
     transform: translateY(-2px);
@@ -268,13 +274,13 @@ h1 {
   box-shadow: var(--shadow-sm);
   border: none;
   color: white;
-  
+
   &:hover {
     transform: translateY(-1px);
     box-shadow: var(--shadow);
     filter: brightness(0.95);
   }
-  
+
   &:active {
     transform: translateY(1px);
     box-shadow: var(--shadow-sm);
@@ -301,9 +307,17 @@ h1 {
 }
 
 @keyframes pulse {
-  0% { opacity: 1; }
-  50% { opacity: 0.7; }
-  100% { opacity: 1; }
+  0% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.7;
+  }
+
+  100% {
+    opacity: 1;
+  }
 }
 
 #interval_time_left {
@@ -316,20 +330,36 @@ h1 {
 }
 
 #interval_current {
-  font-size: 1.5rem;
+  display: block;
+  width: 100%;
+  font-size: 2.25rem;
   color: var(--primary);
-  font-weight: 600;
+  font-weight: 700;
   margin: 0.5rem 0;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+#routine_timer_display {
+  width: 100%;
+  max-width: 900px;
 }
 
 #coming_up {
-  font-size: 1.125rem;
+  /* increased ~25% for better readability */
+  font-size: 1.4rem;
   text-align: left;
   color: var(--text-light);
   padding: 1rem;
   background: #F3F4F6;
   border-radius: 0.5rem;
-  margin: 1rem 0;
+  margin: 1rem auto;
+}
+
+#coming_up ul {
+  margin-left: 2rem;
 }
 
 .buttons {
@@ -338,7 +368,7 @@ h1 {
   justify-content: center;
   width: 100%;
   margin: 1rem 0;
-  
+
   a {
     flex: 1;
     min-width: 120px;
@@ -388,7 +418,7 @@ h1 {
     flex-wrap: wrap;
     gap: 0.5rem;
     padding: 0 0.5rem;
-    
+
     a {
       flex: 1 1 calc(50% - 0.25rem);
       min-width: 0;
@@ -412,9 +442,11 @@ h1 {
   }
 
   #coming_up {
-    font-size: 1rem;
+  /* slightly larger for small screens (~25% up from previous 1rem) */
+  font-size: 1.25rem;
     padding: 0.75rem;
-    margin: 0.5rem;
+    margin: 0.5rem auto;
+    width: 100%;
   }
 
   #time_left {
@@ -432,19 +464,19 @@ h1 {
     font-size: 14px;
     padding: 0.5rem;
   }
-  
+
   .buttons {
     flex-direction: row;
     flex-wrap: wrap;
     gap: 0.75rem;
-    
+
     a {
       flex: 1 1 calc(50% - 0.375rem);
       min-width: 0;
       max-width: none;
     }
   }
-  
+
   #interval_time_left {
     font-size: 3rem;
   }
@@ -467,6 +499,10 @@ h1 {
     scrollbar-width: thin;
     -webkit-overflow-scrolling: touch;
 
+    /* Slightly narrower in portrait to allow left/right padding */
+    width: 90%;
+    margin: 1rem auto;
+
     &::-webkit-scrollbar {
       width: 4px;
     }
@@ -483,13 +519,20 @@ h1 {
 }
 
 // Add smooth animation for details elements
-details[open] summary ~ * {
+details[open] summary~* {
   animation: sweep .3s ease-in-out;
 }
 
 @keyframes sweep {
-  0%    {opacity: 0; transform: translateY(-10px)}
-  100%  {opacity: 1; transform: translateY(0)}
+  0% {
+    opacity: 0;
+    transform: translateY(-10px)
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0)
+  }
 }
 
 // Focus styles for accessibility
@@ -503,7 +546,7 @@ details[open] summary ~ * {
   opacity: 0.7;
   pointer-events: none;
   position: relative;
-  
+
   &::after {
     content: '';
     position: absolute;
@@ -511,17 +554,20 @@ details[open] summary ~ * {
     left: 0;
     width: 100%;
     height: 100%;
-    background: linear-gradient(
-      90deg,
-      transparent,
-      rgba(255,255,255,0.2),
-      transparent
-    );
+    background: linear-gradient(90deg,
+        transparent,
+        rgba(255, 255, 255, 0.2),
+        transparent);
     animation: loading 1.5s infinite;
   }
 }
 
 @keyframes loading {
-  0% { transform: translateX(-100%) }
-  100% { transform: translateX(100%) }
+  0% {
+    transform: translateX(-100%)
+  }
+
+  100% {
+    transform: translateX(100%)
+  }
 }

--- a/src/templates/routine_timer_display.handlebars
+++ b/src/templates/routine_timer_display.handlebars
@@ -9,7 +9,7 @@
     <div id="time_left"><span>{{to_time vm.time_left}}</span> to go</div>
     {{#with vm}}
     {{#with current}}
-        <div id="interval_current"><span>{{group_name}}</span><span> - </span><span>{{name}}</span></div>
+    <div id="interval_current"><span>{{name}}</span></div>
         <div id="interval_time_left"><span>{{to_time time_left}}</span></div>
         <div>{{set_detail}}</div>
     {{/with}}
@@ -18,8 +18,6 @@
         <ul>
         {{#each coming_up}}
         <li>
-            <span>{{group_name}}</span>
-            <span> - </span>
             <span>{{name}}</span>
         </li>
         {{/each}}


### PR DESCRIPTION
Summary

Improve the UI/UX of the routine timer: make the app title act as a home button, confirm exit when a routine is running, remove group headers and group names from the running timer, enlarge the current interval text and coming-up list, widen timer display, and show four upcoming exercises instead of three.