### PR TITLE
chore(deps): bump @babel/core from 7.28.3 to 7.28.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     },
     "homepage": "https://github.com/thegruffalo/fitness_routine_timer#readme",
     "devDependencies": {
-        "@babel/core": "^7.28.3",
+        "@babel/core": "^7.28.4",
         "@babel/plugin-proposal-class-properties": "^7.18.6",
         "@babel/plugin-transform-arrow-functions": "^7.27.1",
         "@babel/plugin-transform-class-properties": "^7.27.1",


### PR DESCRIPTION
Manually resolves the conflicting dependabot PR #111

This updates @babel/core from 7.28.3 to 7.28.4, which is a patch release containing:
- Internal improvements and Jest updates
- Improved TypeScript typings
- Switch to @jridgewell/remapping

Closes #111